### PR TITLE
Verteximpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+/bin/

--- a/src/main/structure/components/Edge.java
+++ b/src/main/structure/components/Edge.java
@@ -2,7 +2,7 @@ package main.structure.components;
 
 import main.structure.contracts.IEdge;
 
-public class Edge <T extends Comparable<T>> implements IEdge{
+public class Edge <T extends Comparable<T>> implements IEdge<T>{
 
 	private Float weight;
 	private Vertex<T> source, destination;

--- a/src/main/structure/components/Vertex.java
+++ b/src/main/structure/components/Vertex.java
@@ -1,13 +1,10 @@
 package main.structure.components;
 
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
-
-import main.structure.contracts.IEdge;
 import main.structure.contracts.IVertex;
 
-public class Vertex <T extends Comparable<T>> implements Comparator<Vertex <T>>, IVertex{
+public class Vertex <T extends Comparable<T>> implements IVertex<T>{
 
 	private T value;
 	private List<Edge<T>> adjacencyList;
@@ -32,15 +29,15 @@ public class Vertex <T extends Comparable<T>> implements Comparator<Vertex <T>>,
 	}
 
 	@Override
-	public void addEdge(IEdge edge) {
-		// TODO Auto-generated method stub
-		
+	public void addEdge(Edge<T> edge) {
+		if (edge != null)
+			adjacencyList.add(edge);
 	}
 
 	@Override
-	public void removeEdge(IEdge edge) {
-		// TODO Auto-generated method stub
-		
+	public void removeEdge(Edge<T> edge) {
+		if (edge != null)
+			adjacencyList.remove(adjacencyList.indexOf(edge));
 	}
 
 	public T getValue() {

--- a/src/main/structure/contracts/IEdge.java
+++ b/src/main/structure/contracts/IEdge.java
@@ -1,5 +1,11 @@
 package main.structure.contracts;
 
-public interface IEdge {
+/**
+ * Edge interface of this graphlib
+ * @author Nicácio Oliveira
+ *
+ * @param <T>
+ */
+public interface IEdge<T extends Comparable<T>> {
 
 }

--- a/src/main/structure/contracts/IVertex.java
+++ b/src/main/structure/contracts/IVertex.java
@@ -1,6 +1,27 @@
 package main.structure.contracts;
 
-public interface IVertex {
-	void addEdge(IEdge edge);
-	void removeEdge(IEdge edge);
+import java.util.Comparator;
+
+import main.structure.components.Edge;
+import main.structure.components.Vertex;
+
+/**
+ * Vertex interface of this graphlib
+ * @author Nicácio Oliveira
+ *
+ * @param <T>
+ */
+public interface IVertex<T extends Comparable<T>> extends Comparator<Vertex<T>>{
+	
+	/**
+	 * Must add an object that represents an edge of the vertex.
+	 * @param edge object
+	 */
+	void addEdge(Edge<T> edge);
+	
+	/**
+	 * Must remove an object that represents an edge of the vertex 
+	 * @param edge object
+	 */
+	void removeEdge(Edge<T> edge);
 }


### PR DESCRIPTION
Correção das interfaces de Edge e Vertex, onde tem o problema lá do tipo genérico.
- Faltava estender o Comparable que a gente queria.
- implementação de addVertex e removeVertex.
- Javadoc simples dessas classes.
